### PR TITLE
Adds liason email to site footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -79,6 +79,7 @@
               <p><a href="#">president@delta.khk.org</a></p>
               <p><a href="#">secretary@delta.khk.org</a></p>
               <p><a href="#">treasurer@delta.khk.org</a></p>
+              <p><a href="#">liaison@delta.khk.org</a></p>
             </li>
             <li>
               <h3>Phone</h3>


### PR DESCRIPTION
## Summary
This PR adds a contact email address for the KHK Liason to the site's footer.

## Testing Instructions
1. In the project root, run `bundle exec jekyll serve`
1. In your browser, navigate to http://localhost:1924
1. Scroll to the bottom of the page
1. Note the liason email address under the **Contact us** heading