### PR TITLE
Fix Event Links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ github_username: kappaetakappa
 
 # Build settings
 markdown: kramdown
+future: true
 
 collections:
   members:


### PR DESCRIPTION
Jekyll, by default, will not publish pages dated in the future. This makes sense in a blogging sense, but does not make sense event listings. This change allows us to make pages dated in the future.